### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+
+language: perl6
+
+perl6:
+    - latest
+
+env:
+    PATH=$PATH:$HOME/silan/bin
+
+install:
+    - rakudobrew build-panda
+    - panda installdeps .
+    # install silan binary so that Audio::Silan can be tested
+    - mkdir -p $HOME/silan
+    - sudo apt-get install libsndfile-dev
+    - wget https://github.com/x42/silan/archive/v0.3.2.tar.gz
+    - tar -xvzf v0.3.2.tar.gz
+    - cd silan-0.3.2 && autoreconf --install && ./configure --prefix=$HOME/silan && make && make install && cd ..

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Audio silence detection using silan (https://github.com/x42/silan)
 
+[![Build Status](https://travis-ci.org/jonathanstowe/Audio-Silan.svg?branch=master)](https://travis-ci.org/jonathanstowe/Audio-Silan)
+
 ## Synopsis
 
 ```


### PR DESCRIPTION
The config downloads a the (at this point in time) most current release of silan and installs it locally so that `Audio::Silan` can use the silan binary in its tests.  Dunno if this is the best way to do it, but it works.  I've also added the Travis badge to the README as you've done in other repos.  If this PR needs any changes, just let me know and I'll patch it appropriately.
